### PR TITLE
Refresh displayed CDP on "manage CDPs" page load

### DIFF
--- a/src/components/RepayContent.jsx
+++ b/src/components/RepayContent.jsx
@@ -6,7 +6,7 @@ import PrimaryButton from './PrimaryButton'
 import Table from './Table'
 import TransactionSummary from './TransactionSummary'
 import LoadingOverlay from './LoadingOverlay'
-import { mint, closeCDP, getCDPs, addCollateral } from '../transactions/cdp'
+import { mint, closeCDP, getCDPs, updateCDPs, addCollateral } from '../transactions/cdp'
 import { getWalletInfo, handleTxError } from '../wallets/wallets'
 import { useNavigate } from 'react-router'
 import { useDispatch, useSelector } from 'react-redux'
@@ -38,7 +38,9 @@ export default function RepayContent() {
   const dispatch = useDispatch()
 
   useEffect(async () => {
+    const updatePromise = updateCDPs()
     let currentPriceResponse = await getCurrentAlgoUsd()
+    await updatePromise
     setCurrentPrice(currentPriceResponse)
   }, [])
   const [modalContent, reduceModalContent] = useReducer(


### PR DESCRIPTION
All I did was add a call to updateCDPs() in the useEffect for the page. So, it'll happen on page load (and probably when other transactions go through)