### PR TITLE
Fixed sidebar scroll

### DIFF
--- a/src/components/Drawer.jsx
+++ b/src/components/Drawer.jsx
@@ -275,7 +275,7 @@ const DrawerDiv = styled.div`
   z-index: 15;
   left: ${`${window.innerWidth < 900 ? -101 : 0}vw`};
   position: ${`${window.innerWidth < 900 ? `absolute` : `fixed`}`};
-  overflow-y: scroll;
+  overflow-y: auto;
   ${(props) =>
     props.animate &&
     css`


### PR DESCRIPTION
Adjusted sidebar so it does not scroll when the window height is at least the sidebar's height. If the window’s height is not big enough to view the entire sidebar, the scroll is enabled.