### PR TITLE
Firebase Web Actions

### DIFF
--- a/src/components/Firebase.jsx
+++ b/src/components/Firebase.jsx
@@ -75,8 +75,7 @@ export async function updateCommitmentFirestore(owner_address, account_id, commi
         console.error("Error adding document: ", e);
     }
 }
-export async function updateLiquidationFirestore(account_id) {
-    const owner_address = getWalletInfo().address
+export async function updateLiquidationFirestore(owner_address, account_id) {
     const cdp_address = cdpGen(owner_address, account_id).address
     const key1 = `ownedCDPs.${cdp_address}.lastCommitment`
     const key2 = `ownedCDPs.${cdp_address}.commitmentTimestamp`
@@ -132,7 +131,6 @@ export async function addCDPToFireStore(account_id, microAlgos, microGARD, feesP
       webappActions: arrayUnion({actionType: 0, cdpAddress: cdp_address, microAlgos: microAlgos, 
         microGARD: microGARD, microGAIN: 0, swapPair: 0, feesPaid: feesPaid, timestamp: Date.now()})
     });
-    console.log('Reopened', cdp_address)
   }
   else{
     await updateDoc(walletRef, {
@@ -140,7 +138,6 @@ export async function addCDPToFireStore(account_id, microAlgos, microGARD, feesP
       webappActions: arrayUnion({actionType: 0, cdpAddress: cdp_address, microAlgos: microAlgos, 
       microGARD: microGARD, microGAIN: 0, swapPair: 0, feesPaid: feesPaid, timestamp: Date.now()})
     });
-    console.log('Added', cdp_address, 'to firestore')
   }
 }
 
@@ -152,7 +149,6 @@ export async function updateDBWebActions(actionType, account_id, microAlgos, mic
     webappActions: arrayUnion({actionType: actionType, cdpAddress: cdp_address, microAlgos: microAlgos, 
       microGARD: microGARD, microGAIN: microGAIN, swapPair: 0, feesPaid: feesPaid, timestamp: Date.now()})
   });
-  console.log('webActionsupdated')
 }
 // [{Action type, CDP address (“0” if not applicable), microAlgos in/out, microGARD in/out, 
 // microGAIN in/out, swapPair (“0” if not applicable”), Fees Paid (in microAlgos), Timestamp}]

--- a/src/components/Firebase.jsx
+++ b/src/components/Firebase.jsx
@@ -69,7 +69,7 @@ export async function updateCommitmentFirestore(owner_address, account_id, commi
             [key1]: commitment_amt,
             [key2]: Date.now(),
             webappActions: arrayUnion({actionType: 4, cdpAddress: cdp_address, microAlgos: 0, 
-            microGARD: 0, microGAIN: 0, swapPair: 0, feesPaid: 1000, timestamp: Date.now()})
+            microGARD: 0, microGAIN: 0, swapPair: 0, feesPaid: 2000, timestamp: Date.now()})
         });
     } catch (e) {
         console.error("Error adding document: ", e);

--- a/src/components/Firebase.jsx
+++ b/src/components/Firebase.jsx
@@ -11,7 +11,8 @@ import {
   updateDoc,
   query,
   where,
-  doc
+  doc,
+  arrayUnion,
 } from "firebase/firestore";
 import { cdpGen } from "../transactions/contracts";
 import { getWalletInfo } from "../wallets/wallets";
@@ -34,6 +35,8 @@ const app = initializeApp(firebaseConfig);
 
 // get the firestore database instance
 const db = getFirestore(app);
+
+const owner_address = getWalletInfo().address
 
 
 export async function addUserToFireStore(user, walletID) {
@@ -84,7 +87,6 @@ export async function updateLiquidationFirestore(owner_address, account_id) {
     }
 }
 export async function loadFireStoreCDPs() {
-    const owner_address = getWalletInfo().address
     const docRef = doc(db, "users", owner_address);
     const docSnap = await getDoc(docRef);
     if (docSnap.exists()) {
@@ -94,3 +96,30 @@ export async function loadFireStoreCDPs() {
     console.log("No such document!");
     }
 }
+
+export async function addCDPToFireStore(account_id) {
+  const cdp_address = cdpGen(owner_address, account_id).address
+  const initStats = {
+      lastCommitment: -1,
+      commitmentTimestamp: -1,
+      liquidatedTimestamp: [-1],
+  };
+  const key = `ownedCDPs.${cdp_address}`
+  const walletRef = doc(db, "users", owner_address);
+  const docRef = await updateDoc(walletRef, {
+      [key] : initStats
+  });
+  console.log('added', cdp_address, 'to firestore')
+}
+
+export async function updateDBWebActions(actionType, account_id, microAlgos, microGARD, microGAIN, feesPaid){
+  const cdp_address = cdpGen(owner_address, account_id).address
+  const walletRef = doc(db, "users", owner_address);
+  await updateDoc(walletRef, {
+    webappActions: arrayUnion({actionType: actionType, cdpAddress: cdp_address, microAlgos: microAlgos, 
+      microGARD: microGARD, microGAIN: microGAIN, swapPair: 0, feesPaid: feesPaid, timestamp: Date.now()})
+  });
+  console.log('webActionsupdated')
+}
+// [{Action type, CDP address (“0” if not applicable), microAlgos in/out, microGARD in/out, 
+// microGAIN in/out, swapPair (“0” if not applicable”), Fees Paid (in microAlgos), Timestamp}]

--- a/src/transactions/cdp.js
+++ b/src/transactions/cdp.js
@@ -655,8 +655,7 @@ export async function closeCDP(accountID, microRepayGARD, payFee = true) {
   }
   let info = await accountInfoPromise;
   let cdp = cdpGen(info.address, accountID);
-  const cdpInfoPromise = accountInfo(cdp.address)
-  let cdpInfo = await cdpInfoPromise
+  let cdpInfo = await accountInfo(cdp.address)
   const cdpBal = cdpInfo.amount
   let gard_bal = getGardBalance(info);
 
@@ -734,7 +733,6 @@ export async function closeCDP(accountID, microRepayGARD, payFee = true) {
   let response = await sendTxn(stxns, "Successfully closed your cdp with ID " + accountID + ".",);
   setLoadingStage(null)
   removeCDP(info.address, accountID);
-  updateLiquidationFirestore(accountID)
   updateDBWebActions(1, accountID, cdpBal - fee, microRepayGARD, 0, fee)
   return response;
   // XXX: May want to do something else besides this, a promise? loading screen?
@@ -995,6 +993,7 @@ export async function liquidate(
   let response = await sendTxn(
     stxns,
     "Successfully liquidated CDP #" + account_id + " of " + owner_address, true);
+    updateLiquidationFirestore(owner_address, account_id)
     setLoadingStage(null)
   return response;
 }

--- a/src/transactions/cdp.js
+++ b/src/transactions/cdp.js
@@ -900,7 +900,7 @@ export async function voteCDP(account_id, option1, option2) {
       " from CDP #" +
       account_id,
   );
-  updateDBWebActions(6, account_id, 0, 0, 0, 1000)
+  updateDBWebActions(6, account_id, 0, 0, 0, 2000)
   setLoadingStage(null)
   return response;
 }

--- a/src/transactions/cdp.js
+++ b/src/transactions/cdp.js
@@ -629,7 +629,7 @@ export async function addCollateral(accountID, newAlgos) {
   const response = await sendTxn(stxns, "Successfully added " + newAlgos + " ALGOs as collateral.",);
   setLoadingStage(null)
 
-  updateDBWebActions(2, accountID, microNewAlgos, 0, 0, 1000)
+  updateDBWebActions(2, accountID, -microNewAlgos, 0, 0, 2000)
   checkChainForCDP(info.address, accountID);
 
   return response;


### PR DESCRIPTION
**Changes made:**
- got rid of all unnecssary "const docRef =" variable initializations
- fixed _updateLiquidation_ function so that it appends the last liquidatedTimestamp to the end of the array instead of setting the last timestamp to its new value. Called _updateLiquidation_ in closeCDP (file: cdp.js)
- added code to update webActions in Firebase when _updateCommitmentFirestore_ or _addCDPtoFireStore_ is called
- _addCDPtoFireStore_ changed so that it does not reset liquidatedTimestamp on reuse of CDP. It queries db to see if the cdp address is in it. If it is, it only updates lastCommitment and commitmentTimestamp to -1, else it initializes the commitmentTimestamp, lastCommitment, and liquidatedTimestamp fields of the cdp address to -1, -1, [-1] respectively.
- created a function to update db when web actions 0-4, or 6 are performed (called in cdp.js)