### PR TITLE
Fixing scroll

### DIFF
--- a/src/components/AuctionsContent.jsx
+++ b/src/components/AuctionsContent.jsx
@@ -190,7 +190,7 @@ export default function AuctionsContent() {
       <div
         style={{
           maxWidth: window.innerWidth - 0.14 * window.innerWidth,
-          overflow: 'scroll',
+          overflow: 'auto',
           display: 'flex',
           flexDirection: 'column',
         }}

--- a/src/components/Modal.jsx
+++ b/src/components/Modal.jsx
@@ -121,7 +121,7 @@ const MainContent = styled.div`
   height: ${window.innerWidth < 900 ? '450px' : '605px'};
   width: ${`${window.innerWidth < 900 ? '90vw' : '835px'}`};
   position: absolute;
-  overflow: scroll;
+  overflow: auto;
   ${(props) =>
     props.animate &&
     css`

--- a/src/components/RepayContent.jsx
+++ b/src/components/RepayContent.jsx
@@ -1,5 +1,5 @@
 import React, { useEffect, useReducer, useState, useContext } from 'react'
-import styled, {css} from 'styled-components'
+import styled, {css, withTheme} from 'styled-components'
 import { formatToDollars, formatTo } from '../utils'
 import Modal from './Modal'
 import PrimaryButton from './PrimaryButton'
@@ -273,7 +273,7 @@ export default function RepayContent() {
       <div
         style={{
           maxWidth: window.innerWidth - 0.14 * window.innerWidth,
-          overflow: 'scroll',
+          overflow: 'auto',
         }}
       >
         <Table

--- a/src/components/WalletContent.jsx
+++ b/src/components/WalletContent.jsx
@@ -184,7 +184,7 @@ export default function WalletContent() {
       <div
         style={{
           maxWidth: window.innerWidth - 0.14 * window.innerWidth,
-          overflow: 'scroll',
+          overflow: 'auto',
         }}
       >
         <Table data={assets} title="Assets" />


### PR DESCRIPTION
When the dark mode is toggled on the web app, certain pages that have overflow set to 'scroll', have scroll bars that are always there but have no functionality unless there is a ton of content that needs to be displayed (e.g., a lot of CDPs open in Repay Content). These scrollbars didn't provide much use and they looked bad in the dark mode because they were white, so I changed the scrollbars to only appear if there was enough content being displayed.