### PR TITLE
Track Gleam Actions through Firebase - opening a CDP

### DIFF
--- a/src/components/Firebase.jsx
+++ b/src/components/Firebase.jsx
@@ -222,3 +222,10 @@ export function queryUser() {
   const q = query(usersRef, where("id", "==", owner_address));
   return q;
 }
+
+export async function addUserToGleam(gleamAction, walletID) {
+  const gleamRef = doc(db, "gleamActions", gleamAction);
+  await updateDoc(gleamRef, {
+    [gleamAction]: arrayUnion(walletID),
+  });
+}

--- a/src/transactions/cdp.js
+++ b/src/transactions/cdp.js
@@ -14,6 +14,7 @@ import {
   addCDPToFireStore,
   updateDBWebActions,
   updateLiquidationFirestore,
+  addUserToGleam
 } from "../components/Firebase";
 import { VERSION, MINID, MAXID } from "../globals";
 
@@ -401,6 +402,7 @@ export async function openCDP(openingALGOs, openingGARD, commit, toWallet) {
   );
   
   addCDPToFireStore(accountID, -openingMicroALGOs, microOpeningGard, 0);
+  addUserToGleam("openCDP", info.address)
   
   if (commit) {
     updateCommitmentFirestore(info.address, accountID, openingMicroALGOs);


### PR DESCRIPTION
Added a new collection to the testnet database called "gleamActions"
- Contains documents that each represent gleam actions (each have an array that stores walletIDs that have completed corresponding actions)

Currently, only opening of CDPs are being recorded. When a user opens a CDP it adds them to the array within gleamActions.openCDP if they are not already in it.