### PR TITLE
Gleam bug

### DIFF
--- a/src/transactions/cdp.js
+++ b/src/transactions/cdp.js
@@ -394,7 +394,11 @@ export async function openCDP(openingALGOs, openingGARD, commit, toWallet) {
   
   addCDPToFireStore(accountID, -openingMicroALGOs, microOpeningGard, 0);
   let completedMint = JSON.parse(localStorage.getItem("gleamMintComplete"))
-  if (completedMint == null | !completedMint.includes(info.address)) {
+  if (completedMint == null){
+    localStorage.setItem("gleamMintComplete", JSON.stringify([]))
+    completedMint = []
+  }
+  if (!completedMint.includes(info.address)) {
     await updateTotal(info.address, "totalMinted", microOpeningGard)
     let user_totals = await loadUserTotals()
     console.log('totals', user_totals)
@@ -411,7 +415,11 @@ export async function openCDP(openingALGOs, openingGARD, commit, toWallet) {
     response.text =
       response.text + "\nFull Balance committed to Governance Period #5!";
       let completedCommit = JSON.parse(localStorage.getItem("gleamCommitComplete"))
-      if (completedCommit == null | !completedCommit.includes(info.address)) {
+      if (completedCommit == null){
+        localStorage.setItem("gleamCommitComplete", JSON.stringify([]))
+        completedCommit = []
+      }
+      if (!completedCommit.includes(info.address)) {
       await updateTotal(info.address, "totalCommitted", openingMicroALGOs)
       let user_totals = await loadUserTotals()
       console.log('totals', user_totals)
@@ -473,8 +481,11 @@ export async function mint(accountID, newGARD) {
   setLoadingStage(null);
   updateDBWebActions(3, accountID, 0, microNewGARD, 0, 0, 0);
   let completedMint = JSON.parse(localStorage.getItem("gleamMintComplete"))
-  console.log("completedMint", completedMint)
-  if (completedMint == null | !completedMint.includes(info.address)) {
+  if (completedMint == null){
+    localStorage.setItem("gleamMintComplete", JSON.stringify([]))
+    completedMint = []
+  }
+  if (!completedMint.includes(info.address)) {
     await updateTotal(info.address, "totalMinted", microGARD(newGARD))
     let user_totals = await loadUserTotals()
     console.log('totals', user_totals)
@@ -903,8 +914,11 @@ export async function commitCDP(account_id, amount, toWallet) {
     parseInt(amount * 1000000),
   );
   let completedCommit = JSON.parse(localStorage.getItem("gleamCommitComplete"))
-  console.log("completedCommit", completedCommit)
-  if ( completedCommit == null | !completedCommit.includes(info.address)) {
+  if (completedCommit == null){
+    localStorage.setItem("gleamCommitComplete", JSON.stringify([]))
+    completedCommit = []
+  }
+  if (!completedCommit.includes(info.address)) {
     await updateTotal(info.address, "totalCommitted", parseInt(amount * 1000000))
     let user_totals = await loadUserTotals()
     console.log('totals', user_totals)

--- a/src/transactions/cdp.js
+++ b/src/transactions/cdp.js
@@ -394,7 +394,7 @@ export async function openCDP(openingALGOs, openingGARD, commit, toWallet) {
   
   addCDPToFireStore(accountID, -openingMicroALGOs, microOpeningGard, 0);
   let completedMint = JSON.parse(localStorage.getItem("gleamMintComplete"))
-  if (!completedMint.includes(info.address)) {
+  if (completedMint == null | !completedMint.includes(info.address)) {
     await updateTotal(info.address, "totalMinted", microOpeningGard)
     let user_totals = await loadUserTotals()
     console.log('totals', user_totals)
@@ -411,7 +411,7 @@ export async function openCDP(openingALGOs, openingGARD, commit, toWallet) {
     response.text =
       response.text + "\nFull Balance committed to Governance Period #5!";
       let completedCommit = JSON.parse(localStorage.getItem("gleamCommitComplete"))
-      if (!completedCommit.includes(info.address)) {
+      if (completedCommit == null | !completedCommit.includes(info.address)) {
       await updateTotal(info.address, "totalCommitted", openingMicroALGOs)
       let user_totals = await loadUserTotals()
       console.log('totals', user_totals)
@@ -473,7 +473,8 @@ export async function mint(accountID, newGARD) {
   setLoadingStage(null);
   updateDBWebActions(3, accountID, 0, microNewGARD, 0, 0, 0);
   let completedMint = JSON.parse(localStorage.getItem("gleamMintComplete"))
-  if (!completedMint.includes(info.address)) {
+  console.log("completedMint", completedMint)
+  if (completedMint == null | !completedMint.includes(info.address)) {
     await updateTotal(info.address, "totalMinted", microGARD(newGARD))
     let user_totals = await loadUserTotals()
     console.log('totals', user_totals)
@@ -902,7 +903,8 @@ export async function commitCDP(account_id, amount, toWallet) {
     parseInt(amount * 1000000),
   );
   let completedCommit = JSON.parse(localStorage.getItem("gleamCommitComplete"))
-  if (!completedCommit.includes(info.address)) {
+  console.log("completedCommit", completedCommit)
+  if ( completedCommit == null | !completedCommit.includes(info.address)) {
     await updateTotal(info.address, "totalCommitted", parseInt(amount * 1000000))
     let user_totals = await loadUserTotals()
     console.log('totals', user_totals)

--- a/src/transactions/stake.js
+++ b/src/transactions/stake.js
@@ -118,7 +118,7 @@ export async function stake(pool, gardAmount) {
     "Successfully staked " + gardAmount + " GARD.",
   );
   let completedStake = JSON.parse(localStorage.getItem("gleamStakeComplete"))
-  if (!completedStake.includes(info.address)) {
+  if (completedStake == null | !completedStake.includes(info.address)) {
     await updateTotal(info.address, "totalStaked", parseInt(gardAmount * 1000000))
     let user_totals = await loadUserTotals()
     console.log('totals', user_totals)

--- a/src/transactions/stake.js
+++ b/src/transactions/stake.js
@@ -118,7 +118,11 @@ export async function stake(pool, gardAmount) {
     "Successfully staked " + gardAmount + " GARD.",
   );
   let completedStake = JSON.parse(localStorage.getItem("gleamStakeComplete"))
-  if (completedStake == null | !completedStake.includes(info.address)) {
+  if (completedStake == null){
+    localStorage.setItem("gleamStakeComplete", JSON.stringify([]))
+    completedStake = []
+  }
+  if (!completedStake.includes(info.address)) {
     await updateTotal(info.address, "totalStaked", parseInt(gardAmount * 1000000))
     let user_totals = await loadUserTotals()
     console.log('totals', user_totals)


### PR DESCRIPTION
I think the error was occurring because people had already had wallets connected, and the gleam localStorage keys were not initialized (which they were supposed to on connecting a wallet).
- Added extra conditional to check if the localStorage is null - if it is we initialize it with an empty array so that the .includes error does get triggered.