### PR TITLE
Fix cdp cacheload

### DIFF
--- a/src/components/Holdings.jsx
+++ b/src/components/Holdings.jsx
@@ -64,7 +64,6 @@ export default function Holdings() {
   const [walletTotal, setWalletTotal] = useState(0);
   const [borrowTotal, setBorrowTotal] = useState(0);
 
-  let assets = getAssets();
   const cdps = CDPsToList();
   const cdpData = cdps.map((cdp, i) => {
     console.log(cdp)
@@ -87,8 +86,7 @@ export default function Holdings() {
   ];
 
   useEffect(() => {
-    let assets = getAssets();
-    let walletSum = accumulateTotal(assets, "value");
+    let walletSum = accumulateTotal(getAssets(), "value");
     let netBorrowSum = accumulateTotal(cdps, "collateral");
     let netBorrowDebt = accumulateTotal(cdps, "debt");
     setWalletTotal(walletSum);

--- a/src/components/Holdings.jsx
+++ b/src/components/Holdings.jsx
@@ -64,7 +64,7 @@ export default function Holdings() {
   const [walletTotal, setWalletTotal] = useState(0);
   const [borrowTotal, setBorrowTotal] = useState(0);
 
-  const assets = getAssets();
+  let assets = getAssets();
   const cdps = CDPsToList();
   const cdpData = cdps.map((cdp, i) => {
     console.log(cdp)
@@ -87,6 +87,7 @@ export default function Holdings() {
   ];
 
   useEffect(() => {
+    let assets = getAssets();
     let walletSum = accumulateTotal(assets, "value");
     let netBorrowSum = accumulateTotal(cdps, "collateral");
     let netBorrowDebt = accumulateTotal(cdps, "debt");

--- a/src/transactions/cdp.js
+++ b/src/transactions/cdp.js
@@ -45,6 +45,30 @@ export async function getPrice() {
 // We immeadiately update the price in a background thread
 getPrice();
 
+let CDPs;
+
+export function getCDPs() {
+  // V1: Only loads from cache
+  // CDPs is a list of CDP dictionaries. These dictionaries include:
+  // {
+  //   collateral: MICROALGOS,
+  //   debt: MICROGARD,
+  // }
+  if (typeof CDPs === 'undefined') {
+    const stored = localStorage.getItem("CDPs");
+    if (stored !== null) {
+      CDPs = JSON.parse(stored);
+    } else {
+      CDPs = {};
+    }
+  }
+  return CDPs;
+}
+
+
+getCDPs()
+
+
 export function calcRatio(collateral, minted, asaID, string = false) {
   // collateral: Microalgos
   // minted: GARD
@@ -130,7 +154,6 @@ async function updateTypeCDPs(address, accountCDPs, asaID) {
 
 export async function updateCDPs(address) {
   // Checks all CDPs by an address
-  const CDPs = getCDPs();
   const accountCDPs = CDPs[address];
   // Sets the frequency to double check CDPs
   updateTypeCDPs(address, accountCDPs, 0)
@@ -138,7 +161,6 @@ export async function updateCDPs(address) {
 }
 
 async function findOpenID(address, asaID) {
-  const CDPs = getCDPs();
   const accountCDPs = CDPs[address];
   const typeCDPs = accountCDPs[asaID]
   for (const x of Array(MAXID - MINID)
@@ -990,7 +1012,6 @@ async function updateCDP(
   const infoPromise = accountInfo(cdp.address);
 
   // Getting the entry to modify
-  let CDPs = getCDPs();
   let accountCDPs = CDPs[address];
   if (accountCDPs == null) {
     accountCDPs = {};
@@ -1039,19 +1060,6 @@ async function updateCDP(
   return false
 }
 
-export function getCDPs() {
-  // V1: Only loads from cache
-  // CDPs is a list of CDP dictionaries. These dictionaries include:
-  // {
-  //   collateral: MICROALGOS,
-  //   debt: MICROGARD,
-  // }
-  let CDPs = localStorage.getItem("CDPs");
-  if (CDPs !== null) {
-    return JSON.parse(CDPs);
-  }
-  return {};
-}
 
 export async function commitCDP(account_id, amount, toWallet) {
   // Setting up promises


### PR DESCRIPTION
This is ready to review, but I built off of #133, so please review/merge that first.

This drastically speeds up CDP caching + loading without causing any negative impacts. This is done by using localstorage only for initiation and backup of state changes.

This can easily be tested by opening several CDPs, using the old codebase, disconnecting, clearing storage, and seeing the population speed, and then doing the same on this branch.