### PR TITLE
Home Page Fixes

### DIFF
--- a/src/components/BinaryToggle.jsx
+++ b/src/components/BinaryToggle.jsx
@@ -102,7 +102,7 @@ const Box = styled.div`
 const Text = styled.text`
   font-weight: 500px;
   text-align: center;
-  margin: 0px 2px 0px 2px;
+  margin: 0px 10px 0px 10px;
   color: #999696;
   cursor: pointer;
   ${(props) =>

--- a/src/components/Drawer.jsx
+++ b/src/components/Drawer.jsx
@@ -126,7 +126,7 @@ export default function Drawer({
       flexDirection: "column",
       justifyContent: "space-between",
       alignItems: "baseline",
-      height: `${mobile ? "9vh" : 0}`
+      height: `${!mobile ? 0 : isOpen ? "" : "9vh"}`
     }} >
        {window.innerWidth < 900 ? <MobileDrawer mobile={mobile} open={isOpen}>
           <LogoButton

--- a/src/components/Drawer.jsx
+++ b/src/components/Drawer.jsx
@@ -126,7 +126,7 @@ export default function Drawer({
       flexDirection: "column",
       justifyContent: "space-between",
       alignItems: "baseline",
-      height: `${isOpen ? "" : "9vh"}`
+      height: `${mobile ? "9vh" : 0}`
     }} >
        {window.innerWidth < 900 ? <MobileDrawer mobile={mobile} open={isOpen}>
           <LogoButton
@@ -166,10 +166,9 @@ export default function Drawer({
           <LogoButton
             style={{
               display: "flex",
+              margin: "auto",
               marginTop: 48,
-              marginLeft: "03.9583333333333vw",
-              marginBottom: 38,
-              visibility: `${mobile || !isOpen ? "hidden" : "visible"}`
+              visibility: `${(mobile && isOpen) ? "hidden" : "visible"}`
             }}
             onClick={() => {
               if (window.innerWidth < 900) toggleOpen();

--- a/src/components/Step.jsx
+++ b/src/components/Step.jsx
@@ -15,6 +15,7 @@ export default function Step({
   link,
   linkText,
   allOpen,
+  mobile,
 }) {
   const walletAddress = useSelector(state => state.wallet.address)
   const [open, setOpen] = useState(false);
@@ -30,7 +31,7 @@ export default function Step({
 
   return (
     <ExpandedStep open={open}>
-      <StepItem onClick={handleOpen} open={open}>
+      <StepItem onClick={handleOpen} open={open} mobile={mobile}>
         <div style={{ marginLeft: 8 }}>{checked ? " √" : ""}{header}</div>
         <div
           style={{
@@ -117,13 +118,14 @@ const StepItem = styled.div`
   text-align: left;
   align-items: center;
   background: #0f1733;
+  border: 1px solid #019fff;
   color: #019fff;
   height: 96px;
   /* width: 60vw; */
   border-radius: 10px;
+  margin: auto;
   margin-top: 20px;
   margin-bottom: 20px;
-  padding: 0px 10px 0px 10px;
   ${(props) =>
     props.open &&
     css`
@@ -138,6 +140,10 @@ const StepItem = styled.div`
       color: #0f1733;
 
     `}
+    ${(props) => props.mobile && css`
+    width: 90%;
+  `}
+  
 `;
 
 const StepButton = styled(PrimaryButton)`

--- a/src/components/Topbar.jsx
+++ b/src/components/Topbar.jsx
@@ -63,7 +63,7 @@ const TopBar = styled.div`
   align-items: center;
   justify-content: space-between;
   padding-left: 36px;
-  padding-right: ${window.innerWidth * 0.077}px;
+  padding-right: ${window.innerWidth * 0.057}px;
 
   ${(props) => props.mobile && css`
     flex-direction: column;
@@ -71,7 +71,7 @@ const TopBar = styled.div`
 
   @media (min-width: ${size.tablet}) {
     width: 100%;
-    margin-left: 8.88vw;
+    margin-left: 2.88vw;
   }
   @media (${device.tablet}) {
     width: 100%;

--- a/src/pages/HomeContent.jsx
+++ b/src/pages/HomeContent.jsx
@@ -250,6 +250,7 @@ export default function HomeContent() {
         <Banner expert={difficulty == "DeFi Expert" ? true : false}>
           <div
             style={{
+              display: "flex",
               justifyContent: "center",
               textAlign: "left",
               alignItems: "center",
@@ -297,9 +298,9 @@ export default function HomeContent() {
                       ),
                     );
               }}
-            >
-              Stake
-            </Link>
+            
+              text="Stake"
+            />
           </div>
         </Banner>
 
@@ -474,21 +475,21 @@ const AccessBox = styled.div`
   }
 `
 
-const Link = styled.text`
+const Link = styled(PrimaryButton)`
   text-decoration: none;
   font-weight: 500;
   color: #172756;
   margin-right: 12px;
   &:hover {
-    color: #03a0ff;
-    cursor: pointer;
+    background-color: #455278
   }
 `;
 
 const Banner = styled.div`
   display: flex;
-  /* width: 90%; */
+  width: 90%; 
   flex-direction: row;
+  border: 1px white solid;
   border-radius: 10px;
   justify-content: space-between;
   text-align: center;

--- a/src/pages/HomeContent.jsx
+++ b/src/pages/HomeContent.jsx
@@ -499,7 +499,8 @@ const Banner = styled.div`
   display: flex;
   width: 100%; 
   flex-direction: row;
-  border: 1px white solid;
+  border: 1px solid white;
+  align-content: center;
   border-radius: 10px;
   justify-content: space-between;
   text-align: center;

--- a/src/pages/HomeContent.jsx
+++ b/src/pages/HomeContent.jsx
@@ -247,7 +247,7 @@ export default function HomeContent() {
         }}
       >
 
-        <Banner expert={difficulty == "DeFi Expert" ? true : false}>
+        <Banner mobile={mobile} expert={difficulty == "DeFi Expert" ? true : false}>
           <div
             style={{
               display: "flex",
@@ -354,7 +354,7 @@ export default function HomeContent() {
           </Text> */}
         </div>
       </div>
-      <div style={{ display: "inline-grid" }}>
+      <div>
         {difficulty === "Help Me Out" ? (
           <StepContainer>
             <Text
@@ -364,12 +364,19 @@ export default function HomeContent() {
               {allOpen ? `Collapse` : `Expand`} All
             </Text>
 
-            <ConnectStep>
-              <Text>
-                {walletAddress ? `  √` : ""} Step 1: Connect Your Wallet
-              </Text>
-              <div>
-                <WalletConnect style={{ alignSelf: "flex-start" }} />
+            <ConnectStep mobile={mobile}>
+              <div style={{
+                display: "flex",
+                width: "100%",
+                justifyContent: "space-between",
+                padding: "0px 10px 0px 10px",
+              }}>
+                <Text>
+                  {walletAddress ? `  √` : ""} Step 1: Connect Your Wallet
+                </Text>
+                <div>
+                  <WalletConnect style={{ alignSelf: "flex-end" }} />
+                </div>
               </div>
             </ConnectStep>
 
@@ -384,6 +391,7 @@ export default function HomeContent() {
               goTo="Swap"
               secondGoTo="Borrow"
               allOpen={allOpen}
+              mobile={mobile}
             />
             <Step
               header="Step 3: Gain Rewards"
@@ -405,11 +413,12 @@ export default function HomeContent() {
               goTo="Stake"
               secondGoTo="Govern"
               allOpen={allOpen}
+              mobile={mobile}
             />
           </StepContainer>
         ) : (
           <div style={{display: "flex", flexDirection: "column"}}>
-            <Text>Quick Access</Text>
+            <BoldText>Quick Actions</BoldText>
             <AccessBox expert={difficulty == "DeFi Expert" ? true : false}>
               {buttons.map((action) => {
                 return (
@@ -431,7 +440,7 @@ export default function HomeContent() {
 }
 
 const ToggleBox = styled.div`
-  margin: 8px 0px 8px 0px;
+  margin: 0px 0px 30px 0px;
   @media (${device.tablet}) {
 
   }
@@ -454,6 +463,7 @@ const AccessBox = styled.div`
   display: flex;
   justify-content: center;
   width: 100%;
+  margin-top: 20px;
   margin-bottom: 100px;
   align-items: center;
   ${(props) =>
@@ -487,7 +497,7 @@ const Link = styled(PrimaryButton)`
 
 const Banner = styled.div`
   display: flex;
-  width: 90%; 
+  width: 100%; 
   flex-direction: row;
   border: 1px white solid;
   border-radius: 10px;
@@ -504,7 +514,7 @@ const Banner = styled.div`
       /* margin-left: 60px; */
       /* width: 100%; */
     `
-  }
+    }
   }
   ${(props) =>
     props.expert &&
@@ -512,13 +522,16 @@ const Banner = styled.div`
       /* margin-right: 30px; */
     `
   }
+  ${(props) => props.mobile && css`
+    width: 90%;
+  `}
 `
 
 
 const Container = styled.div`
   background: #0E1834;
   padding-top: 30px;
-  /* width: 90%; */
+  width: 100%;
   padding-bottom: 30px;
   border: 1px solid white;
   border-radius: 10px;
@@ -566,20 +579,21 @@ const Item = styled.div`
 // styled components
 const StepContainer = styled.div`
   display: flex;
-  /* width: 90%; */
   flex-direction: column;
   justify-content: space-evenly;
+  align-content: center;
   align-items: center;
   margin-bottom: 50px;
 `;
 
 const ConnectStep = styled.div`
-  padding: 0px 10px 0px 10px;
   display: flex;
   font-weight: 500;
   font-size: large;
   text-align: left;
   align-items: center;
+  width: 100%;
+  border: 1px solid #019fff;
   background: #0f1733;
   color: #019fff;
   border-radius: 10px;
@@ -608,12 +622,23 @@ const ConnectStep = styled.div`
     @media (${device.mobileL}) {
       //
     }
+    ${(props) => props.mobile && css`
+    width: 90%;
+    `}
 `;
 
 const Text = styled.text`
   font-weight: 500px;
   cursor: pointer;
   margin: 0px 14px 0px 0px;
+  text-align: center;
+  align-self: center;
+`;
+
+const BoldText = styled.text`
+  font-weight: bold;
+  cursor: pointer;
+  margin: 0px 30px 0px 0px;
   text-align: center;
   align-self: center;
 `;


### PR DESCRIPTION
- Fixed logo visibility and properly center it in the navbar
- Fixed weird whitespace at the top
- Fixed spacing of reward banner
- Made step width consistent
- Added appropriate amount of space between quick access and defi expert buttons
- Adjusted spacing of top-bar
- Added a blue border around steps like Figma design
- Adjusted widths of banner and steps on mobile according to Figma as best as possible
- Added a button for “Stake” in the banner instead of just plain text
- Changed the width of the banner and stats container to be in accordance with Figma
- Added bold font for “Quick Actions” (also changed it from ‘Access’ to ‘Actions’)
- Fixed spacing for the toggle button (vertically and spacing the text correctly)