### PR TITLE
Borrow page Staging Fixes

### DIFF
--- a/src/components/BorrowMore.jsx
+++ b/src/components/BorrowMore.jsx
@@ -51,10 +51,10 @@ export default function BorrowMore({ supplyPrice, collateral, mAsset, minted, cd
       },
     ]
     return <div>
-        <div style={{marginTop: 30}}>
+        <div style={{marginTop: 20}}>
             <BorrowCDP  minted={minted} cdp={cdp} price={price} setCurrentCDP={setCurrentCDP} maxMint={maxMint} apr={apr} manageUpdate={manageUpdate} setUtilization={setUtilization}/>
         </div>
-        <div style={{position:"relative", top:-65}}>
+        <div style={{position:"relative", top:-57}}>
             <Details details={borrowDetails}/>
         </div>
     </div>

--- a/src/components/Positions.jsx
+++ b/src/components/Positions.jsx
@@ -438,6 +438,7 @@ export default function Positions({cdp, maxGARD, maxSupply}) {
                           price={price}
                           setCurrentCDP={setCurrentCDP}
                           details={details}
+                          mobile={mobile}
                         />
                       ) : (
                         // : selectedTab === "three" ?
@@ -507,6 +508,7 @@ export default function Positions({cdp, maxGARD, maxSupply}) {
 
 const Sply = styled.div`
   display: flex;
+  margin-bottom: 20px;
   @media (${device.laptop}) {
     flex-direction: column;
   }
@@ -535,7 +537,7 @@ const Brr = styled.div`
 const APRBox = styled.div`
   display: flex;
   @media (min-width: ${size.tablet}) {
-    padding-top: 25px;
+    padding-top: 10px;
   }
 `;
 
@@ -574,10 +576,8 @@ const PositionSupplyBorrow = styled.div`
   display: flex;
   flex-direction: column;
   @media (min-width: ${size.tablet}) {
-    row-gap: 20;
   }
   ${(props) => !props.mobile && css`
-      row-gap: 20px;
 
 
   `}
@@ -601,6 +601,7 @@ const PositionContainer = styled.div`
   display: flex;
   flex-direction: column;
   align-items: center;
+  margin-top: 10px;
   /* flex: 1 1 0px; */
   width: auto;
 `;

--- a/src/components/RepayPosition.jsx
+++ b/src/components/RepayPosition.jsx
@@ -11,7 +11,7 @@ import { setAlert } from "../redux/slices/alertSlice";
 import LoadingOverlay from "./LoadingOverlay";
 import Details from "./Details";
 
-export default function RepayPosition({cdp, price, setCurrentCDP, details}){
+export default function RepayPosition({cdp, price, setCurrentCDP, details, mobile}){
     const [loading, setLoading] = useState(false);
     const [loadingText, setLoadingText] = useState(null);
     const dispatch = useDispatch();
@@ -31,7 +31,7 @@ export default function RepayPosition({cdp, price, setCurrentCDP, details}){
         document.addEventListener("itemInserted", sessionStorageSetHandler, false);
 
 
-    return <div style={{marginTop: 30}}>
+    return <div style={{marginTop: 20}}>
             {loading ? <LoadingOverlay
             text={loadingText}
             close={()=>{
@@ -39,7 +39,7 @@ export default function RepayPosition({cdp, price, setCurrentCDP, details}){
             }}
             /> : <></>}
             <Container>
-            <SubContainer>
+            <SubContainer mobile={mobile}>
                 <Background>
                     <Title>Repay GARD</Title>
                     <InputContainer>
@@ -86,7 +86,7 @@ export default function RepayPosition({cdp, price, setCurrentCDP, details}){
                 />
             </SubContainer>
         </Container>
-        <div style={{position:"relative", top:-65}}>
+        <div style={{position:"relative", top:-28}}>
             <Details details={details}/>
         </div>
 </div>
@@ -95,13 +95,15 @@ export default function RepayPosition({cdp, price, setCurrentCDP, details}){
 const Container = styled.div`
     display: flex;
     position: relative;
-    top: -40px;
     justify-content: center;
 `
 
 const SubContainer = styled.div`
     position: relative;
     width: 50%;
+    ${(props) => props.mobile && css`
+        width: 100%;
+    `}
 `
 const Background = styled.div`
     margin-top: 30px;

--- a/src/components/SupplyCDP.jsx
+++ b/src/components/SupplyCDP.jsx
@@ -288,8 +288,7 @@ const InputContainer = styled.div`
 
 const InputDetails = styled.div`
   display: grid;
-  grid-template-columns: repeat(2, 30%);
-  row-gap: 30px;
+  grid-template-columns: repeat(2, 50%);
   justify-content: center;
   padding: 30px 0px 30px;
   border-radius: 10px;

--- a/src/components/SupplyMore.jsx
+++ b/src/components/SupplyMore.jsx
@@ -51,10 +51,10 @@ export default function SupplyMore({ collateralType, supplyPrice, cAsset, collat
       ]
     // TODO: combine SupplyCDP & BorrowCDP
     return <div>
-        <div style={{marginTop: 30}}>
+        <div style={{marginTop: 20}}>
             <SupplyCDP collateralType={collateralType} collateral={collateral} minted={minted}  cdp={cdp} price={price} setCurrentCDP={setCurrentCDP} maxSupply={maxSupply} manageUpdate={manageUpdate} apr={apr} setUtilization={setUtilization}/>
         </div>
-        <div style={{position:"relative", top:-65}}>
+        <div style={{position:"relative", top:-57}}>
             <Details details={supplyDetails}/>
         </div>
     </div>

--- a/src/components/actions/StakeDetails.jsx
+++ b/src/components/actions/StakeDetails.jsx
@@ -503,6 +503,9 @@ const Link = styled.text`
 
 const Banner = styled.div`
   display: flex;
+  width: 100%;
+  border: 1px solid white;
+  align-content: center;
   flex-direction: row;
   border-radius: 10px;
   justify-content: space-between;

--- a/src/pages/BorrowContent.jsx
+++ b/src/pages/BorrowContent.jsx
@@ -652,9 +652,12 @@ const V1Link = styled.text`
 
 const Banner = styled.div`
   display: flex;
+  width: 100%;
+  border: 1px solid white;
   flex-direction: row;
   border-radius: 10px;
   justify-content: space-between;
+  align-content: center;
   text-align: center;
   background: linear-gradient(to right, #80deff 65%, #ffffff);
   padding: 8px 6px 10px 8px;

--- a/src/pages/GovernContent.jsx
+++ b/src/pages/GovernContent.jsx
@@ -597,6 +597,9 @@ const Link = styled.text`
 
 const Banner = styled.div`
   display: flex;
+  width: 100%;
+  border: 1px solid white;
+  align-content: center;
   flex-direction: row;
   border-radius: 10px;
   justify-content: space-between;

--- a/src/styles/mobile.css
+++ b/src/styles/mobile.css
@@ -55,7 +55,7 @@
 
 @media (min-width: 768px) {
   .m-positions_row_1 {
-    padding-bottom: 25px;
+    padding-bottom: 10px;
   }
   .m-positions_row_2 {
     padding-bottom: 25px;


### PR DESCRIPTION
- Changed banner width for all pages
- Added white border to banner
- Vertically aligned all text for banners
- Added spacing below the “Create new position” button
- Fixed position information to replicate the alignment of “CDP Health” header and data
- Readjusted the spacing for repay position and added a gap between the bottom of the Supply and Borrow boxes and their respective details boxes.
- Readjusted the size of the “supply more”  and “borrow more” boxes to be the same and adjusted the size of the “repay” modal on mobile
- adjusted the spacing of the details for Supply more (they were too bunched together before)