### PR TITLE
Fix mobile drawer mechanics

### DIFF
--- a/src/components/Drawer.jsx
+++ b/src/components/Drawer.jsx
@@ -178,7 +178,7 @@ export default function Drawer({
             <NavLogo src={logo} alt="logo" />
           </LogoButton>
         <CloseButton
-          style={{visibility: `${mobile && isOpen ? "visible" : "unset"}`}}
+          style={{visibility: `${mobile && isOpen ? "visible" : "hidden"}`}}
           onClick={() => {
             closeDrawer();
           }}
@@ -246,6 +246,7 @@ export default function Drawer({
                       }  else {
                         // if (window.innerWidth < parseInt(size.tablet)) toggleOpen();
                         navigate(v.route);
+                        closeDrawer();
                       }
                     }}
                   >


### PR DESCRIPTION
- Fixed mobile drawer so that it closes after you click on the tab you want to navigate to
- Removed weird looking close button that was visible on chrome mobile debugger