### PR TITLE
GP 418: Auctions Page

### DIFF
--- a/src/assets/tooltiptext.js
+++ b/src/assets/tooltiptext.js
@@ -44,4 +44,6 @@ module.exports = {
     "Total Committed" : "Amount of ALGOs from CDPs that are currently commited to governance",
     "Volume" : "Number of GARD exchanged in the pas week",
     "Your Stake" : "Number of GARD earning rewards in the pool. Also, number of GARD entitled to withdraw.",
+    "Live Auctions" : "When another user’s collateral approaches the value of their debt, it is sold at auction to pay off their debt. You may purchase Algos/gAlgos with GARD at a discount.",
+    "System Metrics" : "Measurements of TVL, Staked GARD, and Circulating GARD in GARD ecosystem"
 };

--- a/src/components/Effect.jsx
+++ b/src/components/Effect.jsx
@@ -15,12 +15,12 @@ export default function Effect({ title, val, hasToolTip, className, rewards, noM
             toolTip={title}
             toolTipText={tips[title]}
           ></NewToolTip>
-          <hr style={{ border: "dashed 1px" }} />
+          <hr style={{ border: "dashed 1px", margin: "0px 0px 7px" }} />
         </div>
       ) : (
         <div>
           <Text className={className}>{title}</Text>
-          <hr style={{ border: "dashed 1px" }} />
+          <hr style={{ border: "dashed 1px", margin: "0px 0px 7px" }} />
         </div>
       )}
       {rewards ? <RewardWrapper text={val} /> : <Result>{val}</Result>}

--- a/src/components/PageToggle.jsx
+++ b/src/components/PageToggle.jsx
@@ -1,6 +1,7 @@
 import React, { useState } from "react";
 import styled, { css } from "styled-components";
 import { device } from "../styles/global";
+import Effect from "./Effect";
 
 export default function PageToggle({ selectedTab, tabs, className }) {
   const [one, setOne] = useState(true);
@@ -21,7 +22,7 @@ export default function PageToggle({ selectedTab, tabs, className }) {
           }
         }}
       >
-        <Btn selected={one}>{tabs.one}</Btn>
+        <Effect title={tabs.one} hasToolTip={true} noMarginBottom={true}><Btn selected={one}>{tabs.one}</Btn></Effect>
       </Box>
       {tabs.two ? (
         <Box

--- a/src/pages/AuctionsContent.jsx
+++ b/src/pages/AuctionsContent.jsx
@@ -83,6 +83,8 @@ export default function AuctionsContent() {
       action: value.cdp.activeAuction ? (
         <PrimaryButton
           text={"Purchase"}
+          blue={true}
+          left_align={true}
           onClick={() => {
             setTransInfo([
               {


### PR DESCRIPTION
- Added popup definition to Live auctions Tab
- Added popup definition to System Metrics Tab (for consistency)
- Change purple ‘purchase’ button to blue and vertically aligned with the Action item above