### PR TITLE
GP-539: Add safari "enable pop-ups" msg for first time connections

### DIFF
--- a/src/components/WalletConnect.jsx
+++ b/src/components/WalletConnect.jsx
@@ -19,7 +19,7 @@ import { cdpGen } from "../transactions/contracts";
 import { useNavigate } from "react-router-dom";
 import { ids } from "../transactions/ids"
 import { size, device } from "../styles/global"
-import { isMobile } from "../utils";
+import { isMobile, isSafari } from "../utils";
 
 const instantiateUser = async (address) => {
   let accountCDPs = getCDPs()[address];
@@ -167,6 +167,9 @@ export default function WalletConnect() {
               if (walletAddress) {
                 navigate("/account");
               } else {
+                if(isSafari()){
+                  dispatch(setAlert('We noticed you are using safari. Please make sure to <a href="https://www.avast.com/c-allow-and-block-pop-ups-safari">enable pop-ups</a> to use our web app properly!'))
+                }
                 reduceModalContent("terms");
                 setModalCanAnimate(true);
                 setModalVisible(true);

--- a/src/utils.js
+++ b/src/utils.js
@@ -62,6 +62,10 @@ export function isFirefox() {
   return navigator.userAgent.includes("Firefox")
 }
 
+export function isSafari() {
+  return navigator.userAgent.search("Safari") >= 0 && navigator.userAgent.search("Chrome") < 0
+}
+
 export const px2vw = (size, width = 1440) => `${(size / width) * 100}vw`;
 
 export const isMobile = () => /Android|webOS|iPhone|iPad|iPod|BlackBerry|IEMobile|Opera Mini/i.test(navigator.userAgent);


### PR DESCRIPTION
Added popup encouraging user to "enable pop-ups" if they use safari on connection of wallet.

Note: Added link to https://www.avast.com/c-allow-and-block-pop-ups-safari embedded in "enable popups". Another option would be adding the url to the bottom of the popup. Let me know if this would be preferred.