### PR TITLE
GP-572 & GP-579: Update all banners + Desktop Homepage Style update

### DIFF
--- a/src/components/Holdings.jsx
+++ b/src/components/Holdings.jsx
@@ -14,7 +14,7 @@ import { getAccruedRewards } from "../transactions/stake";
 import { algo } from "crypto-js";
 
 function getAssets(alg_price) {
-  var assets = [];
+  var assets = [{name: "ALGO", amount: getWalletInfo().amount/1e6, value: parseFloat(alg_price*getWalletInfo().amount/1e6).toFixed(3)}];
   let x = getWalletInfo()["assets"];
   for (var i = 0, len = x.length; i < len; i++) {
     if ([ids.asa.gard, ids.asa.gain, ids.asa.gardian, ids.asa.galgo].includes(x[i]["asset-id"])) {

--- a/src/components/Step.jsx
+++ b/src/components/Step.jsx
@@ -152,7 +152,7 @@ const StepButton = styled(PrimaryButton)`
 `;
 
 const ExpandedStep = styled.div`
-  width: 100%;
+  width: 90%;
 `;
 
 const StepText = styled.text`

--- a/src/components/actions/StakeDetails.jsx
+++ b/src/components/actions/StakeDetails.jsx
@@ -89,7 +89,10 @@ export default function StakeDetails() {
   };
 
   const handleStake = async () => {
-    if (stakeAmount === null || !(stakeAmount > 0)) return;
+    if (stakeAmount === null || !(stakeAmount > 0)) {
+      dispatch(setAlert("You must enter a positive amount to Stake!"))
+      return
+    }
     setLoading(true)
     try {
       const res = await stake("NL", stakeAmount)
@@ -104,7 +107,10 @@ export default function StakeDetails() {
   }
 
   const handleUnstake = async () => {
-    if (stakeAmount === null || !(stakeAmount > 0)) return;
+    if (stakeAmount === null || !(stakeAmount > 0)) {
+      dispatch(setAlert("You must enter a positive amount to Unstake!"))
+      return
+    }
     setLoading(true)
     try {
       const res = await unstake("NL", stakeAmount)
@@ -119,7 +125,10 @@ export default function StakeDetails() {
   }
 
   const handleStake2 = async () => {
-    if (stake2Amount === null || !(stake2Amount > 0)) return;
+    if (stake2Amount === null || !(stake2Amount > 0)) {
+      dispatch(setAlert("You must enter a positive amount to Stake!"))
+      return
+    }
     setLoading(true)
     try {
       const res = await GardianStake("NL", parseInt(stake2Amount))
@@ -134,7 +143,10 @@ export default function StakeDetails() {
   }
 
   const handleUnstake2 = async () => {
-    if (stake2Amount === null || !(stake2Amount > 0)) return;
+    if (stake2Amount === null || !(stake2Amount > 0)) {
+      dispatch(setAlert("You must enter a positive amount to Unstake!"))
+      return
+    }
     setLoading(true)
     try {
       const res = await GardianUnstake("NL", parseInt(stake2Amount))

--- a/src/components/actions/StakeDetails.jsx
+++ b/src/components/actions/StakeDetails.jsx
@@ -204,6 +204,7 @@ export default function StakeDetails() {
         <Banner>
           <div
             style={{
+              display: "flex",
               justifyContent: "center",
               textAlign: "left",
               alignItems: "center",
@@ -226,10 +227,11 @@ export default function StakeDetails() {
                 display: "flex",
                 textAlign: "left",
                 flexDirection: "column",
+                marginLeft: "10px",
               }}
             >
               <div style={{ color: "#172756", fontSize: "10pt" }}>
-                1k - 2k GARD being paid out WEEKLY for users staking GARD!
+                1k - 2k extra GARD being paid out WEEKLY for users staking GARD!
               </div>
             </div>
           </div>
@@ -616,10 +618,11 @@ const Banner = styled.div`
   border-radius: 10px;
   justify-content: space-between;
   text-align: center;
-  background: linear-gradient(to right, #80deff 65%, #ffffff);
+  background: linear-gradient(to right, #019FFF 40%, #ffffff);
   padding: 8px 6px 10px 8px;
   margin: 8px;
   margin-bottom: 12px;
+  min-height: 37.5px;
 `
 
 

--- a/src/pages/BorrowContent.jsx
+++ b/src/pages/BorrowContent.jsx
@@ -346,6 +346,27 @@ export default function BorrowContent() {
       ) : (
         <></>
       )}
+      <div
+        style={{
+          display: "flex",
+          flexDirection: "column",
+          alignItems: "center",
+        }}
+      >
+      <Banner mobile={mobile}>
+        <div
+          style={{
+            justifyContent: "center",
+            margin: "auto",
+            alignItems: "center",
+            color: "#172756",
+          }}
+        >
+          <div style={{ color: "#172756", fontSize: "10pt" }}>
+            <span style={{ fontSize: "12pt", color: "#172756", fontWeight: "bold" }}>Notice:</span> GARD borrow APR is fixed at 2% it will not change without warning
+          </div>
+        </div>
+      </Banner>
       {/*
       <Banner>
         <div
@@ -571,6 +592,7 @@ export default function BorrowContent() {
           <Positions maxSupply={maxCollateral} maxGARD={maxGARD} />
         </div>
       )}
+      </div>
     </div>
   );
 }
@@ -596,17 +618,20 @@ const V1Link = styled.text`
 
 const Banner = styled.div`
   display: flex;
-  width: 100%;
+  min-height: 37.5px;
   border: 1px solid white;
   flex-direction: row;
   border-radius: 10px;
   justify-content: space-between;
   align-content: center;
   text-align: center;
-  background: linear-gradient(to right, #80deff 65%, #ffffff);
+  background: linear-gradient(to right, #019FFF 40%, #ffffff);
   padding: 8px 6px 10px 8px;
   margin: 8px;
   margin-bottom: 20px;
+  ${(props) => props.mobile && css`
+    width: 90%;
+  `}
 `;
 
 const BorrowRewardNotice = styled(RewardNotice)`

--- a/src/pages/HomeContent.jsx
+++ b/src/pages/HomeContent.jsx
@@ -157,9 +157,9 @@ export async function getTotalGardGovs() {
 }
 
 const buttons = [
+  "Borrow",
   "Swap",
   "Stake",
-  "Borrow",
   "Govern",
   "Auctions",
   // "Analytics",
@@ -339,7 +339,7 @@ export default function HomeContent() {
               color: "#172756",
             }}
           >
-            <div style={{ fontSize: "10pt" }}>GARD Staking Rewards!</div>
+            <div style={{ fontSize: "12pt" }}>GARD Staking Rewards!</div>
           </div>
           <div
             style={{
@@ -358,8 +358,7 @@ export default function HomeContent() {
               }}
             >
               <div style={{ color: "#172756", fontSize: "10pt", textAlign: "center" }}>
-                Earn protocol rewards boosted by the Algorand Foundation via
-                Aeneas grant!
+              Earn protocol revenues boosted by the Algorand Foundation!
               </div>
             </div>
           </div>
@@ -478,7 +477,7 @@ export default function HomeContent() {
                       disabled={!walletAddress}
                       text={action}
                       blue={true}
-                      uniform={mobile}
+                      uniform={true}
                       onClick={() => navigate(`/${action.toLowerCase()}`)}
                     />
                   </div>
@@ -527,7 +526,7 @@ export default function HomeContent() {
             <ConnectStep mobile={mobile}>
               <div style={{
                 display: "flex",
-                width: "100%",
+                width: "90%",
                 justifyContent: "space-between",
                 padding: "0px 10px 0px 10px",
               }}>
@@ -643,14 +642,14 @@ const Link = styled(PrimaryButton)`
 
 const Banner = styled.div`
   display: flex;
-  width: 100%; 
+  width: 90%; 
   flex-direction: row;
   border: 1px solid white;
   align-content: center;
   border-radius: 10px;
   justify-content: space-between;
   text-align: center;
-  background: linear-gradient(to right, #80deff 65%, #ffffff);
+  background: linear-gradient(to right, #019FFF 40%, #ffffff);
   padding: 8px 6px 10px 8px;
   margin: 8px;
   @media (${device.tablet}) {
@@ -678,7 +677,7 @@ const Banner = styled.div`
 const Container = styled.div`
   background: #0E1834;
   padding-top: 30px;
-  width: 100%;
+  width: 90%;
   padding-bottom: 30px;
   border: 1px solid white;
   border-radius: 10px;
@@ -738,7 +737,7 @@ const ConnectStep = styled.div`
   font-size: large;
   text-align: left;
   align-items: center;
-  width: 100%;
+  width: 90%;
   border: 1px solid #019fff;
   background: #0f1733;
   color: #019fff;


### PR DESCRIPTION
- Improved home banner on desktop and mobile view (increased size of “GARD Staking Rewards)
- Updated banner text to requested texts from Jira description
- Changed gradient of banner to match mockups
- Made all home page containers and banners less wide
- Homogenized the sized of the quick action buttons on home page
- Reordered quick actions so that “borrow” is the first from the left