### PR TITLE
GP-574: Borrow Page Mobile

### DIFF
--- a/src/components/BorrowMore.jsx
+++ b/src/components/BorrowMore.jsx
@@ -5,10 +5,21 @@ import {displayRatio, mAlgosToAlgos, displayLiquidationPrice, getMinted, getColl
 import { calcRatio } from "../transactions/cdp";
 
 
-export default function BorrowMore({ supplyPrice, collateral, mAsset, minted, cdp, price, setCurrentCDP, maxMint,  manageUpdate, apr}) {
+export default function BorrowMore({ supplyPrice, collateral, mAsset, minted, cdp, price, setCurrentCDP, maxMint,  manageUpdate, apr, mobile}) {
     const [utilization, setUtilization] = useState(null)
     // TODO: combine SupplyCDP & BorrowCDP
-    let borrowDetails = [
+    let borrowDetails = mobile ? [
+      {
+        title: "Liquidation Price",
+        val: `$${mAsset == null || mAsset == "" ? ((1.15 * (mAlgosToAlgos(cdp.debt)) / (mAlgosToAlgos(cdp.collateral))).toFixed(4)) : ((1.15 * (mAlgosToAlgos(cdp.debt) + mAsset) / (mAlgosToAlgos(cdp.collateral))).toFixed(4))}`,
+        hasToolTip: true,
+      },
+      {
+        title: "ALGO Governance APR",
+        val: `${apr}%`,
+        hasToolTip: true,
+      },
+    ] : [
       {
         title: "Total Supplied (Asset)",
         val: `${mAlgosToAlgos(cdp.collateral + (collateral !== "" ? collateral : 0)).toFixed(2)}`,
@@ -55,7 +66,7 @@ export default function BorrowMore({ supplyPrice, collateral, mAsset, minted, cd
             <BorrowCDP  minted={minted} cdp={cdp} price={price} setCurrentCDP={setCurrentCDP} maxMint={maxMint} apr={apr} manageUpdate={manageUpdate} setUtilization={setUtilization}/>
         </div>
         <div style={{position:"relative", top:-57}}>
-            <Details details={borrowDetails}/>
+            <Details mobile={mobile} details={borrowDetails}/>
         </div>
     </div>
 }

--- a/src/components/ClosePosition.jsx
+++ b/src/components/ClosePosition.jsx
@@ -1,0 +1,261 @@
+import React, { useState } from "react";
+import { useDispatch } from "react-redux";
+import { useNavigate } from "react-router-dom";
+import styled, {css} from "styled-components";
+import Effect from "./Effect";
+import ToolTip from "./ToolTip";
+import PrimaryButton from "./PrimaryButton";
+import { handleTxError } from "../wallets/wallets";
+import { setAlert } from "../redux/slices/alertSlice";
+import LoadingOverlay from "./LoadingOverlay";
+import Details from "./Details";
+import { mAlgosToAlgos } from "../pages/BorrowContent";
+import { closeCDP } from "../transactions/cdp";
+
+
+export default function ClosePosition({cdp, price, setCurrentCDP, details, mobile, apr }){
+    const [loading, setLoading] = useState(false);
+    const [loadingText, setLoadingText] = useState(null);
+    const dispatch = useDispatch();
+    const [repayment, setRepayment] = useState("")
+
+    const handleRepay = (event) => {
+        setRepayment(event.target.value === "" ? "" : Number(event.target.value));
+    };
+    
+    var details = mobile ? [
+        {
+          title: "Liquidation Price",
+          val: `$${
+            (1.15*(cdp.debt-parseInt(repayment*1e6))/cdp.collateral).toFixed(3)
+          }`,
+          hasToolTip: true,
+        },
+        {
+          title: "Collateralization Ratio",
+          val: `${
+            (100*cdp.collateral*price / (cdp.debt - parseInt(repayment*1e6))).toFixed(0)
+          }%`,
+          hasToolTip: true,
+        },
+  ]
+  : [
+        {
+            title: "Total Supplied (Asset)",
+            val: `${cdp.collateral/1e6}`,
+            hasToolTip: true,
+          },
+          {
+            title: "Total Supplied ($)",
+            val: `${`$${(cdp.collateral/1e6 * price).toFixed(2)}`}`,
+            hasToolTip: true,
+          },
+          {
+            title: "Collateral Factor",
+            val: `${(100 / 140).toFixed(2)}`,
+            hasToolTip: true,
+          },
+          {
+            title: "Borrow Utilization",
+            val: `${
+              (100*(cdp.debt - parseInt(repayment*1e6)) / (cdp.collateral * price / 1.4)).toFixed(2)}
+            %`,
+            hasToolTip: true,
+          },
+          {
+            title: "Liquidation Price",
+            val: `$${
+              (1.15*(cdp.debt-parseInt(repayment*1e6))/cdp.collateral).toFixed(3)
+            }`,
+            hasToolTip: true,
+          },
+          // {
+          //   title: "GARD Borrow APR",
+          //   val: 0,
+          //   hasToolTip: true,
+          // },
+          {
+            title: "ALGO Governance APR",
+            val: `${apr}%`,
+            hasToolTip: true,
+          },
+          {
+            title: "Collateralization Ratio",
+            val: `${
+              (100*cdp.collateral*price / (cdp.debt - parseInt(repayment*1e6))).toFixed(0)
+            }%`,
+            hasToolTip: true,
+          },
+    ];
+
+    var borrowDetails = [
+      {
+        title: "Already Borrowed",
+        val: `${mAlgosToAlgos(cdp.debt).toFixed(2)}`,
+        hasToolTip: true
+      },
+      {
+        title: "Borrow Limit",
+        val: `${Math.max(
+          0,
+          Math.trunc(
+            (100 * ((price * cdp.collateral) / 1000000)) / 1.4 -
+              (100 * cdp.debt) / 1000000,
+          ) / 100,
+        )} GARD`,
+        hasToolTip: true,
+      },
+    ];
+
+    var sessionStorageSetHandler = function (e) {
+        setLoadingText(JSON.parse(e.value));
+        };
+
+        document.addEventListener("itemInserted", sessionStorageSetHandler, false);
+
+    
+    return <div style={{marginTop: 20}}>
+            {loading ? <LoadingOverlay
+            text={loadingText}
+            close={()=>{
+                setLoading(false);
+            }}
+            /> : <></>}
+            <Container>
+            <SubContainer mobile={mobile}>
+                <Background>
+                    <Title>Close Position</Title>
+                    <InputContainer>
+                        <div style={{display: "flex"}}>
+                            <Input
+                            autoComplete="off"
+                            display="none"
+                            placeholder={"enter amount"}
+                            type='number'
+                            min="0.00"
+                            id="repay"
+                            value={mAlgosToAlgos(cdp.debt).toFixed(2)}
+                            />
+                            <MaxButton>
+                                <ToolTip toolTip={"+MAX"} toolTipText={"Max amount is already being repaid"}/>
+                            </MaxButton>
+                        </div>
+                        <Valuation>$Value: ${(mAlgosToAlgos(cdp.debt)).toFixed(2)}</Valuation>
+                        <InputDetails>
+                        {borrowDetails.length && borrowDetails.length > 0
+                          ? borrowDetails.map((d) => {
+                              return (
+                                <Item key={d.title}>
+                                  <Effect
+                                    title={d.title}
+                                    val={d.val}
+                                    hasToolTip={d.hasToolTip}
+                                  ></Effect>
+                                </Item>
+                              );
+                            })
+                          : null}
+                        </InputDetails>
+                    </InputContainer>
+                </Background>
+                <PrimaryButton
+                blue={true}
+                positioned={true}
+                text="Close Position"
+                onClick={async () => {
+                    setLoading(true);
+                    try {
+                    let res = await closeCDP(cdp.id, cdp.asaID);
+                    if (res.alert) {
+                        dispatch(setAlert(res.text));
+                    }
+                    } catch (e) {
+                    handleTxError(e, "Error minting from CDP");
+                    }
+                    setLoading(false);
+                    setCurrentCDP(null);
+                }}
+                />
+            </SubContainer>
+        </Container>
+        <div style={{position:"relative", top:-28}}>
+            <Details mobile={mobile} details={details}/>
+        </div>
+</div>
+
+}
+const Container = styled.div`
+    display: flex;
+    position: relative;
+    justify-content: center;
+`
+
+const SubContainer = styled.div`
+    position: relative;
+    ${(props) => props.mobile && css`
+        width: 100%;
+    `}
+`
+const Background = styled.div`
+    margin-top: 30px;
+    background: #1b2d65;
+    border-radius: 10px;
+`
+const Title = styled.div`
+    display: flex;
+    justify-content: center;
+    text-align: center;
+    padding: 20px 0px 20px;
+`
+
+const InputContainer = styled.div`
+    background: rgba(13, 18, 39, .75);
+    border-radius: 10px;
+    border: 1px solid white;
+`
+
+const InputDetails = styled.div`
+  display: grid;
+  grid-template-columns: repeat(2, 49%);
+  row-gap: 30px;
+  justify-content: center;
+  padding: 30px 0px 30px;
+  border-radius: 10px;
+`;
+
+const Item = styled.div`
+    display: flex;
+    flex-direction: column;
+    font-size: 14px;
+`
+const MaxButton = styled.button`
+    color: #01d1ff;
+    background: none;
+    border: none;
+    margin-top: 50px;
+    cursor: pointer;
+    font-size: 12px;
+`
+const Valuation = styled.div`
+    margin-left: 25px;
+    margin-top: 3px;
+    font-size: 12px;
+    color: #999696;
+`
+const Input = styled.input`
+  padding-top: 35px;
+  border-radius: 0;
+  height: 30px;
+  width: 80%;
+  color: white;
+  text-decoration: none;
+  border: none;
+  border-bottom: 2px solid #01d1ff;
+  opacity: 100%;
+  font-size: 20px;
+  background: none;
+  margin-left: 25px;
+  &:focus {
+      outline-width: 0;
+    }
+`

--- a/src/components/Details.jsx
+++ b/src/components/Details.jsx
@@ -51,10 +51,10 @@ const Items = styled.div`
     grid-template-columns: repeat(2, 44%);
   }
   @media (${device.mobileM}) {
-    grid-template-columns: repeat(1, 80%);
+    grid-template-columns: repeat(2, 44%);
   }
   ${(props) => props.mobile && css`
-  grid-template-columns: repeat(1, 80%);
+  grid-template-columns: repeat(2, 44%);
   `}
 `;
 

--- a/src/components/Drawer.jsx
+++ b/src/components/Drawer.jsx
@@ -291,7 +291,8 @@ export default function Drawer({
             );
           })}
         </div>
-        <div>
+        <div
+          /*
           <div style={{
             position: "relative",
             bottom: -15,
@@ -304,8 +305,8 @@ export default function Drawer({
           </div>
           <div style={{ position: "relative", "margin-left": "auto", "margin-right": "auto", maxWidth: "80%", transform: "scale(0.75)"}}>
             <CountdownTimer targetDate={commitmentPeriodEnd} showZero={new Date().getTime() > commitmentPeriodEnd} />
-          </div>
-        </div>
+          </div> */
+        ></div>
         <div style={{
           top: "85vh", left: 0, right: 0
           }}>

--- a/src/components/Positions.jsx
+++ b/src/components/Positions.jsx
@@ -13,6 +13,7 @@ import PageToggle from "./PageToggle";
 import BorrowMore from "./BorrowMore";
 import SupplyMore from "./SupplyMore";
 import RepayPosition from "./RepayPosition";
+import ClosePosition from "./ClosePosition";
 import { setAlert } from "../redux/slices/alertSlice";
 import LoadingOverlay from "./LoadingOverlay";
 import { ids } from "../transactions/ids";
@@ -193,7 +194,7 @@ export default function Positions({cdp, maxGARD, maxSupply}) {
   const tabs = {
     one: "Borrow More",
     two: "Supply More",
-    three: "Repay Position",
+    three: "Partial Repay",
     four: "Close Position",
   };
   useEffect(async () => {
@@ -251,7 +252,7 @@ export default function Positions({cdp, maxGARD, maxSupply}) {
                         </div>
                       </Brr>
                     </PositionSupplyBorrow>
-                    <div
+                    {mobile ? <></> : <div
                       className="m_positions_item m-positions_box_2"
                       style={{ display: "flex", flexDirection: "column" }}
                     >
@@ -264,7 +265,7 @@ export default function Positions({cdp, maxGARD, maxSupply}) {
                           {`  ` + apr}%
                         </span>
                       </APRBox>
-                    </div>
+                    </div>}
                     <div
                       className="m_positions_item m-positions_box_3"
                       style={{ display: "flex", flexDirection: "column" }}
@@ -361,6 +362,7 @@ export default function Positions({cdp, maxGARD, maxSupply}) {
                           maxMint={maxGARD}
                           apr={apr}
                           manageUpdate={setManageUpdate}
+                          mobile={mobile}
                         />
                       ) : selectedTab === "two" ? (
                         <SupplyMore
@@ -375,6 +377,7 @@ export default function Positions({cdp, maxGARD, maxSupply}) {
                           maxSupply={maxSupply}
                           apr={apr}
                           manageUpdate={setManageUpdate}
+                          mobile={mobile}
                         />
                       ) : selectedTab === "three" ? (
                         <RepayPosition
@@ -416,26 +419,33 @@ export default function Positions({cdp, maxGARD, maxSupply}) {
                         //         </SalesInfo>
                         //         <PrimaryButton text="List for Sale" purple={true} disabled={true} />
                         // </div>
-                        <div style={{ marginTop: 40 }}>
-                          <PrimaryButton
-                            text="Close Position"
-                            positioned={true}
-                            blue={true}
-                            onClick={async () => {
-                              setLoading(true);
-                              try {
-                                let res = await closeCDP(cdp.id, cdp.asaID);
-                                if (res.alert) {
-                                  dispatch(setAlert(res.text));
-                                }
-                              } catch (e) {
-                                handleTxError(e, "Error minting from CDP");
-                              }
-                              setLoading(false);
-                              setCurrentCDP(null);
-                            }}
-                          />
-                        </div>
+                        <ClosePosition
+                          cdp={cdp}
+                          price={price}
+                          setCurrentCDP={setCurrentCDP}
+                          mobile={mobile}
+                          apr={apr}
+                        />
+                        // <div style={{ marginTop: 40 }}>
+                        //   <PrimaryButton
+                        //     text="Close Position"
+                        //     positioned={true}
+                        //     blue={true}
+                        //     onClick={async () => {
+                        //       setLoading(true);
+                        //       try {
+                        //         let res = await closeCDP(cdp.id, cdp.asaID);
+                        //         if (res.alert) {
+                        //           dispatch(setAlert(res.text));
+                        //         }
+                        //       } catch (e) {
+                        //         handleTxError(e, "Error minting from CDP");
+                        //       }
+                        //       setLoading(false);
+                        //       setCurrentCDP(null);
+                        //     }}
+                        //   />
+                        // </div>
                       )}
                     </ToggleContainer>
                   ) : (
@@ -461,6 +471,7 @@ const Sply = styled.div`
   }
   ${(props) => props.mobile && css`
     flex-direction: row;
+    margin-bottom: 8px;
   `}
 `;
 

--- a/src/components/RepayPosition.jsx
+++ b/src/components/RepayPosition.jsx
@@ -10,6 +10,7 @@ import { handleTxError } from "../wallets/wallets";
 import { setAlert } from "../redux/slices/alertSlice";
 import LoadingOverlay from "./LoadingOverlay";
 import Details from "./Details";
+import { mAlgosToAlgos } from "../pages/BorrowContent";
 
 export default function RepayPosition({cdp, price, setCurrentCDP, details, mobile, apr}){
     const [loading, setLoading] = useState(false);
@@ -24,7 +25,24 @@ export default function RepayPosition({cdp, price, setCurrentCDP, details, mobil
     //console.log(cdp)
     // console.log("YEah")
     
-    var details = [
+    
+    var details = mobile ? [
+        {
+          title: "Liquidation Price",
+          val: `$${
+            (1.15*(cdp.debt-parseInt(repayment*1e6))/cdp.collateral).toFixed(3)
+          }`,
+          hasToolTip: true,
+        },
+        {
+          title: "Collateralization Ratio",
+          val: `${
+            (100*cdp.collateral*price / (cdp.debt - parseInt(repayment*1e6))).toFixed(0)
+          }%`,
+          hasToolTip: true,
+        },
+  ]
+  : [
         {
             title: "Total Supplied (Asset)",
             val: `${cdp.collateral/1e6}`,
@@ -72,6 +90,24 @@ export default function RepayPosition({cdp, price, setCurrentCDP, details, mobil
             hasToolTip: true,
           },
     ];
+    var borrowDetails = [
+      {
+        title: "Already Borrowed",
+        val: `${mAlgosToAlgos(cdp.debt).toFixed(2)}`,
+        hasToolTip: true
+      },
+      {
+        title: "Borrow Limit",
+        val: `${Math.max(
+          0,
+          Math.trunc(
+            (100 * ((price * cdp.collateral) / 1000000)) / 1.4 -
+              (100 * cdp.debt) / 1000000,
+          ) / 100,
+        )} GARD`,
+        hasToolTip: true,
+      },
+    ];
 
     var sessionStorageSetHandler = function (e) {
         setLoadingText(JSON.parse(e.value));
@@ -108,6 +144,21 @@ export default function RepayPosition({cdp, price, setCurrentCDP, details, mobil
                             </MaxButton>
                         </div>
                         <Valuation>$Value: ${(repayment * 1).toFixed(2)}</Valuation>
+                        <InputDetails>
+                        {borrowDetails.length && borrowDetails.length > 0
+                          ? borrowDetails.map((d) => {
+                              return (
+                                <Item key={d.title}>
+                                  <Effect
+                                    title={d.title}
+                                    val={d.val}
+                                    hasToolTip={d.hasToolTip}
+                                  ></Effect>
+                                </Item>
+                              );
+                            })
+                          : null}
+                        </InputDetails>
                     </InputContainer>
                 </Background>
                 <PrimaryButton
@@ -136,7 +187,7 @@ export default function RepayPosition({cdp, price, setCurrentCDP, details, mobil
             </SubContainer>
         </Container>
         <div style={{position:"relative", top:-28}}>
-            <Details details={details}/>
+            <Details mobile={mobile} details={details}/>
         </div>
 </div>
 
@@ -149,7 +200,6 @@ const Container = styled.div`
 
 const SubContainer = styled.div`
     position: relative;
-    width: 50%;
     ${(props) => props.mobile && css`
         width: 100%;
     `}
@@ -170,17 +220,16 @@ const InputContainer = styled.div`
     background: rgba(13, 18, 39, .75);
     border-radius: 10px;
     border: 1px solid white;
-    padding-bottom: 35px;
 `
 
 const InputDetails = styled.div`
-display: grid;
-grid-template-columns:repeat(3, 30%);
-row-gap: 30px;
-justify-content: center;
-padding: 30px 0px 30px;
-border-radius: 10px;
-`
+  display: grid;
+  grid-template-columns: repeat(2, 49%);
+  row-gap: 30px;
+  justify-content: center;
+  padding: 30px 0px 30px;
+  border-radius: 10px;
+`;
 
 const Item = styled.div`
     display: flex;

--- a/src/components/SupplyMore.jsx
+++ b/src/components/SupplyMore.jsx
@@ -4,10 +4,21 @@ import Details from "./Details";
 import { mAlgosToAlgos, algosToMAlgos} from "../pages/BorrowContent"
 import { calcRatio } from "../transactions/cdp";
 
-export default function SupplyMore({ collateralType, supplyPrice, cAsset, collateral, minted, cdp, price, setCurrentCDP, maxSupply, manageUpdate, apr}) {
+export default function SupplyMore({ collateralType, supplyPrice, cAsset, collateral, minted, cdp, price, setCurrentCDP, maxSupply, manageUpdate, apr, mobile}) {
     const [utilization, setUtilization] = useState(null)
     const suppliedAmount = mAlgosToAlgos(cdp.collateral) + (cAsset !== "" ? cAsset : 0)
-    let supplyDetails = [
+    let supplyDetails = mobile ? [
+      {
+        title: "Liquidation Price",
+        val: `$${cAsset == null || cAsset == "" ? ((1.15 * mAlgosToAlgos(cdp.debt)) / (mAlgosToAlgos(cdp.collateral))).toFixed(4) : ((1.15 * mAlgosToAlgos(cdp.debt)) / (mAlgosToAlgos(cdp.collateral) + cAsset)).toFixed(4)}`,
+        hasToolTip: true,
+      },
+      {
+        title: "Total Supplied ($)",
+        val: `$${((Number(suppliedAmount * supplyPrice))).toFixed(2)}`,
+        hasToolTip: true,
+      },
+    ] : [
         {
           title: "Total Supplied (Asset)",
           val: `${suppliedAmount.toFixed(2)}`,
@@ -55,7 +66,7 @@ export default function SupplyMore({ collateralType, supplyPrice, cAsset, collat
             <SupplyCDP collateralType={collateralType} collateral={collateral} minted={minted}  cdp={cdp} price={price} setCurrentCDP={setCurrentCDP} maxSupply={maxSupply} manageUpdate={manageUpdate} apr={apr} setUtilization={setUtilization}/>
         </div>
         <div style={{position:"relative", top:-57}}>
-            <Details details={supplyDetails}/>
+            <Details mobile={mobile} details={supplyDetails}/>
         </div>
     </div>
 }

--- a/src/pages/BorrowContent.jsx
+++ b/src/pages/BorrowContent.jsx
@@ -411,7 +411,7 @@ export default function BorrowContent() {
           <Container mobile={mobile}>
             <SubContainer>
               <Background>
-                <Title>
+                <Title mobile={mobile}>
                   Supply{" "}
                   <ExchangeSelect
                     options={assets}
@@ -419,7 +419,7 @@ export default function BorrowContent() {
                     callback={handleSelect}
                   />
                   {/* ALGO */}
-                  <AlgoImg src={borrowIcon} isGAlgo={!isGAlgo} />
+                  <AlgoImg mobile={mobile} src={borrowIcon} isGAlgo={!isGAlgo} />
                 </Title>
                 <InputContainer>
                   <div style={{ display: "flex" }}>
@@ -432,6 +432,7 @@ export default function BorrowContent() {
                       id="collateral"
                       value={cAlgos}
                       onChange={handleSupplyChange}
+                      mobile={mobile}
                     />
                     <MaxButton onClick={handleMaxCollateral}>
                       <ToolTip
@@ -444,7 +445,7 @@ export default function BorrowContent() {
                     $Value: $
                     {cAlgos === "..." ? 0.0 : (cAlgos * supplyPrice).toFixed(2)}
                   </Valuation>
-                  <SupplyInputDetails>
+                  <SupplyInputDetails mobile={mobile}>
                     {supplyDetails.length && supplyDetails.length > 0
                       ? supplyDetails.map((d) => {
                           return (
@@ -489,8 +490,8 @@ export default function BorrowContent() {
 
             <SubContainer>
               <Background>
-                <BorrowTitle>
-                  Borrow GARD <GardImg src={gardLogo} />
+                <BorrowTitle mobile={mobile}>
+                  Borrow GARD <GardImg mobile={mobile} src={gardLogo} />
                 </BorrowTitle>
 
                 <InputContainer>
@@ -504,6 +505,7 @@ export default function BorrowContent() {
                       value={mGARD}
                       size="small"
                       onChange={handleBorrowChange}
+                      mobile={mobile}
                     />
                     <MaxButton onClick={handleMaxBorrow}>
                       <ToolTip
@@ -513,7 +515,7 @@ export default function BorrowContent() {
                     </MaxButton>
                   </div>
                   <Valuation>$Value: ${mGARD === "" ? 0 : mGARD}</Valuation>
-                  <BorrowInputDetails>
+                  <BorrowInputDetails mobile={mobile}>
                     {borrowDetails.length && borrowDetails.length > 0
                       ? borrowDetails.map((d) => {
                           return (
@@ -648,6 +650,10 @@ const AlgoImg = styled.img`
       margin-bottom: 12.5px;
     `
   }
+  ${(props) => props.mobile && css`
+  height: 30px
+  width: 30px;
+  `}
 `;
 
 const gAlgoImg = styled.img`
@@ -657,10 +663,14 @@ const gAlgoImg = styled.img`
 `
 
 const GardImg = styled.img`
-  height: 50px;
-  margin: 2px 18px 2px 14px;
+  height: 40px;
+  margin: 17.5px 18px 17.5px 18px;
   position: relative;
   top: -2px;
+  ${(props) => props.mobile && css`
+  height: 30px
+  margin: 17.5px 19.86px 17.5px 19.86px;
+  `}
 `;
 
 const Container = styled.div`
@@ -703,6 +713,9 @@ const Title = styled.div`
   align-items: center;
   text-align: center;
   padding: 20px 0px 20px;
+  ${(props) => props.mobile && css`
+  padding: 0px 0px 0px;
+  `}
 `;
 
 const BorrowTitle = styled.div`
@@ -712,8 +725,9 @@ const BorrowTitle = styled.div`
   align-items: center;
   text-align: center;
   padding: 20px 0px 20px;
-  margin-bottom: 9px;
-  padding-top: 31px;
+  ${(props) => props.mobile && css`
+  padding: 0px 0px 0px;
+  `}
 `;
 
 const InputContainer = styled.div`
@@ -736,6 +750,10 @@ const SupplyInputDetails = styled.div`
   justify-content: center;
   padding: 30px 0px 30px;
   border-radius: 10px;
+  ${(props) => props.mobile && css`
+  padding: 15px 0px 15px;
+  row-gap: 15px;
+  `}
 `;
 
 const BorrowInputDetails = styled.div`
@@ -745,6 +763,10 @@ display: grid;
   justify-content: center;
   padding: 30px 0px 30px;
   border-radius: 10px;
+  ${(props) => props.mobile && css`
+  padding: 15px 0px 15px;
+  row-gap: 15px;
+  `}
 `
 
 const Item = styled.div`
@@ -782,6 +804,9 @@ const Input = styled.input`
   &:focus {
     outline-width: 0;
   }
+  ${(props) => props.mobile && css`
+  padding-top: 15px;
+  `}
 `;
 
 const CommitBox = styled.input`

--- a/src/pages/BorrowContent.jsx
+++ b/src/pages/BorrowContent.jsx
@@ -267,7 +267,22 @@ export default function BorrowContent() {
     setLoadingText(JSON.parse(e.value));
   };
   document.addEventListener("itemInserted", sessionStorageSetHandler, false);
-  var details = [
+  var details = mobile ? [
+    {
+      title: "GARD Borrow APR",
+      val: `${cdpInterest*100}%`,
+      hasToolTip: true,
+    },
+    {
+      title: "Liquidation Price",
+      val: `${
+        getMinted() == null || getCollateral() == null
+          ? "..."
+          : displayLiquidationPrice()
+      }`,
+      hasToolTip: true,
+    },
+  ] :[
     {
       title: "Total Supplied (Asset)",
       val: `${cAlgos === "" ? "..." : cAlgos}`,
@@ -551,7 +566,9 @@ export default function BorrowContent() {
               setLoading(false);
             }}
           />
-          <Details mobile={mobile} className={"borrow"} details={details} />
+          <CreateDetails mobile={mobile}>
+            <Details mobile={mobile} className={"borrow"} details={details} />
+          </CreateDetails>
         </div>
       ) : (
         <></>
@@ -559,7 +576,7 @@ export default function BorrowContent() {
       {cdps == dummyCDPs ? (
         <></>
       ) : (
-        <div>
+        <PositionsContainer mobile={mobile}>
           <PrimaryButton
             text={createPositionShown ? "Exit" : "Create New Position"}
             blue={true}
@@ -569,7 +586,7 @@ export default function BorrowContent() {
             }}
           />
           <Positions maxSupply={maxCollateral} maxGARD={maxGARD} />
-        </div>
+        </PositionsContainer>
       )}
     </div>
   );
@@ -652,11 +669,24 @@ const Container = styled.div`
   column-gap: 2%;
   @media (${device.tablet}) {
     grid-template-columns: 1fr;
+    margin: auto;
+    transform: scale(0.9);
+    // max-width: 90vw;
   }
   ${(props) => props.mobile && css`
     grid-template-columns: 1fr;
+    margin: auto;
+    transform: scale(0.9);
+    // max-width: 90vw;
   `}
 `;
+
+const PositionsContainer = styled.div`
+${(props) => props.mobile && css`
+    margin: auto;
+    width: 90%;
+  `}
+`
 
 const SubContainer = styled.div`
   position: relative;
@@ -692,6 +722,13 @@ const InputContainer = styled.div`
   border: 1px solid white;
 `;
 
+const CreateDetails = styled.div`
+${(props) => props.mobile && css`
+  margin: auto;
+  transform: scale(0.9);
+  // max-width: 90vw;
+`}
+`
 const SupplyInputDetails = styled.div`
   // display: grid;
   grid-template-columns: repeat(1, 40%);


### PR DESCRIPTION
Mobile Changes:
- removed governance APR 
- cut down the space between Supplied and borrowed text
- reduced input box width when creating a new CDP 
- reduced space and made logos smaller in supply algo and borrow GARD areas
- eliminated all fields in create positions details besides Borrow APR and Liquidation price, 
- show liquidation price and another relevant field for each of the "supply more", "borrow more", etc detail boxes
- updated Repay position to “partial repay”
- made a close position box to make things look similar to partial repay with fields maxed out.

Dekstop Changes:
- changed the gard logo size in borrow GARD (when opening CDP) because it seemed to big